### PR TITLE
fix crear/edit para actualizar impuestos

### DIFF
--- a/backend/src/main/java/com/orange/Crisalis/model/SellableGood.java
+++ b/backend/src/main/java/com/orange/Crisalis/model/SellableGood.java
@@ -17,15 +17,8 @@ import java.util.Set;
 @NoArgsConstructor
 public class SellableGood {
   @Id
-  @SequenceGenerator(
-      name = "sellable_good_sequence",
-      sequenceName = "sellable_good_sequence",
-      allocationSize = 1,
-      initialValue = 0
-  )
   @GeneratedValue(
-      strategy = GenerationType.SEQUENCE,
-      generator = "sellable_good_sequence"
+      strategy = GenerationType.IDENTITY
   )
   private Long id;
 

--- a/backend/src/main/java/com/orange/Crisalis/model/Tax.java
+++ b/backend/src/main/java/com/orange/Crisalis/model/Tax.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,7 +34,7 @@ public class Tax {
         },
         mappedBy = "taxes")
     @JsonIgnore
-    private Set<SellableGood> sellableGoods;
+    private Set<SellableGood> sellableGoods = new HashSet<>();
 
     public Tax(String taxName, Double taxPercentage) {
         this.taxName = taxName;


### PR DESCRIPTION
Al realizar el testeo de los endpoints de create/edit se encontro que solo guardan/actualizan el producto/servicio. Se realizaron modificaciones para que  guardan/actualizan los impuestos del producto/servicio.